### PR TITLE
boolean properties shold start with 'is' prefix

### DIFF
--- a/src/main/java/com/oembedler/moon/graphql/engine/relay/PageInfoObjectType.java
+++ b/src/main/java/com/oembedler/moon/graphql/engine/relay/PageInfoObjectType.java
@@ -42,12 +42,20 @@ public class PageInfoObjectType {
     @GraphQLDescription("When paginating forwards, the cursor to continue.")
     private String endCursor;
 
+    public Boolean isHasNextPage() {
+        return getHasNextPage();
+    }
+
     public Boolean getHasNextPage() {
         return hasNextPage;
     }
 
     public void setHasNextPage(Boolean hasNextPage) {
         this.hasNextPage = hasNextPage;
+    }
+
+    public Boolean isHasPreviousPage() {
+        return getHasPreviousPage();
     }
 
     public Boolean getHasPreviousPage() {


### PR DESCRIPTION
according to graphql.schema.PropertyDataFetcher.getPropertyViaGetter boolean properties shold start with 'is' prefix
