### PR TITLE
* add possibility to configure custom scalar types externally

### DIFF
--- a/src/main/java/com/oembedler/moon/graphql/engine/GraphQLSchemaConfig.java
+++ b/src/main/java/com/oembedler/moon/graphql/engine/GraphQLSchemaConfig.java
@@ -19,7 +19,13 @@
 
 package com.oembedler.moon.graphql.engine;
 
+import com.oembedler.moon.graphql.engine.dfs.GraphQLTypeResolver;
+import com.oembedler.moon.graphql.engine.type.resolver.DateTypeResolver;
+import com.oembedler.moon.graphql.engine.type.resolver.LocalDateTimeResolver;
 import org.springframework.util.Assert;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author <a href="mailto:java.lang.RuntimeException@gmail.com">oEmbedler Inc.</a>
@@ -37,6 +43,12 @@ public class GraphQLSchemaConfig {
     private String schemaMutationObjectName = "Mutation";
     private boolean dateAsTimestamp = true;
     private String dateFormat = "yyyy-MM-dd'T'HH:mm'Z'";
+    private List<GraphQLTypeResolver> graphQLTypeResolvers = new ArrayList<>();
+
+    {
+        graphQLTypeResolvers.add(new DateTypeResolver());
+        graphQLTypeResolvers.add(new LocalDateTimeResolver());
+    }
 
     // ---
 
@@ -115,6 +127,15 @@ public class GraphQLSchemaConfig {
     public void setDateFormat(String dateFormat) {
         Assert.notNull(dateFormat, "Date format string can not be null!");
         this.dateFormat = dateFormat;
+    }
+
+    public void addGraphQLTypeResolver(GraphQLTypeResolver graphQLTypeResolver) {
+        Assert.notNull(graphQLTypeResolver, "GraphQl resolver cannot be null!");
+        this.graphQLTypeResolvers.add(graphQLTypeResolver);
+    }
+
+    public List<GraphQLTypeResolver> getGraphQLTypeResolvers() {
+        return graphQLTypeResolvers;
     }
 
     public boolean isDateAsTimestamp() {

--- a/src/main/java/com/oembedler/moon/graphql/engine/dfs/GraphQLMappingContext.java
+++ b/src/main/java/com/oembedler/moon/graphql/engine/dfs/GraphQLMappingContext.java
@@ -20,14 +20,10 @@
 package com.oembedler.moon.graphql.engine.dfs;
 
 import com.oembedler.moon.graphql.engine.GraphQLSchemaConfig;
-import com.oembedler.moon.graphql.engine.type.GraphQLDateType;
-import com.oembedler.moon.graphql.engine.type.GraphQLLocalDateTimeType;
 import graphql.schema.GraphQLScalarType;
 import org.springframework.util.Assert;
 
 import java.lang.reflect.Type;
-import java.time.LocalDateTime;
-import java.util.Date;
 
 /**
  * @author <a href="mailto:java.lang.RuntimeException@gmail.com">oEmbedler Inc.</a>
@@ -43,26 +39,17 @@ public class GraphQLMappingContext {
 
     public GraphQLScalarType getScalarGraphQLType(final Type cls) {
         GraphQLScalarType graphQLScalarType = MappingConstants.getScalarGraphQLType(cls);
-        if (Date.class.isAssignableFrom((Class<?>) cls)) {
-            if (graphQLSchemaConfig.isDateAsTimestamp())
-                graphQLScalarType = MappingConstants.graphQLTimestamp;
-            else
-                graphQLScalarType = getGraphQLDateType();
-        } else if (LocalDateTime.class.isAssignableFrom((Class<?>) cls)) {
-            if (graphQLSchemaConfig.isDateAsTimestamp())
-                graphQLScalarType = MappingConstants.graphQLTimestamp;
-            else
-                graphQLScalarType = getGraphQLDateType();
+
+        if (graphQLScalarType == null) {
+            graphQLScalarType = graphQLSchemaConfig.getGraphQLTypeResolvers()
+                    .stream()
+                    .filter(resolver -> resolver.getType().isAssignableFrom((Class<?>) cls))
+                    .findFirst()
+                    .map(resolver -> resolver.resolve(graphQLSchemaConfig))
+                    .orElse(null);
         }
+
         return graphQLScalarType;
-    }
-
-    private GraphQLScalarType getGraphQLDateType() {
-        return new GraphQLDateType("Date", "Date formatted according to defined format string", graphQLSchemaConfig.getDateFormat());
-    }
-
-    private GraphQLScalarType getGraphQLLocalDateTimeType() {
-        return new GraphQLLocalDateTimeType("LocalDateTime", "LocalDateTime formatted according to defined format string", graphQLSchemaConfig.getDateFormat());
     }
 
     // ---

--- a/src/main/java/com/oembedler/moon/graphql/engine/dfs/GraphQLSchemaDfsTraversal.java
+++ b/src/main/java/com/oembedler/moon/graphql/engine/dfs/GraphQLSchemaDfsTraversal.java
@@ -288,7 +288,7 @@ public class GraphQLSchemaDfsTraversal {
                     .deprecate(resolvableTypeAccessor.getGraphQLDeprecationReason())
                     .description(resolvableTypeAccessor.getDescription());
 
-            boolean isConstant = Modifier.isFinal(field.getModifiers()) && Modifier.isStatic(field.getModifiers());
+            boolean isConstant = isPublicConstant(field);
             if (isConstant) {
                 graphQLFieldDefinitionBuilder.staticValue(org.springframework.util.ReflectionUtils.getField(field, null));
             }
@@ -297,6 +297,13 @@ public class GraphQLSchemaDfsTraversal {
         }
 
         return graphQLFieldDefinition;
+    }
+
+    private boolean isPublicConstant(Field field) {
+        int modifiers = field.getModifiers();
+        return Modifier.isFinal(modifiers)
+                && Modifier.isStatic(modifiers)
+                && !Modifier.isPrivate(modifiers);
     }
 
     public void addToFieldDefinitionResolverMap(DfsContext dfsContext, GraphQLFieldDefinition graphQLFieldDefinition, String complexitySpelExpression) {

--- a/src/main/java/com/oembedler/moon/graphql/engine/dfs/GraphQLTypeResolver.java
+++ b/src/main/java/com/oembedler/moon/graphql/engine/dfs/GraphQLTypeResolver.java
@@ -1,0 +1,14 @@
+package com.oembedler.moon.graphql.engine.dfs;
+
+import com.oembedler.moon.graphql.engine.GraphQLSchemaConfig;
+import graphql.schema.GraphQLScalarType;
+
+/**
+ * @author Sergey Kuptsov
+ * @since 23/03/2017
+ */
+public interface GraphQLTypeResolver {
+    Class getType();
+
+    GraphQLScalarType resolve(GraphQLSchemaConfig graphQLSchemaConfig);
+}

--- a/src/main/java/com/oembedler/moon/graphql/engine/type/resolver/DateTypeResolver.java
+++ b/src/main/java/com/oembedler/moon/graphql/engine/type/resolver/DateTypeResolver.java
@@ -1,0 +1,31 @@
+package com.oembedler.moon.graphql.engine.type.resolver;
+
+import com.oembedler.moon.graphql.engine.GraphQLSchemaConfig;
+import com.oembedler.moon.graphql.engine.dfs.GraphQLTypeResolver;
+import com.oembedler.moon.graphql.engine.dfs.MappingConstants;
+import com.oembedler.moon.graphql.engine.type.GraphQLDateType;
+import graphql.schema.GraphQLScalarType;
+
+import java.util.Date;
+
+/**
+ * @author Sergey Kuptsov
+ * @since 23/03/2017
+ */
+public class DateTypeResolver implements GraphQLTypeResolver {
+
+    @Override
+    public Class getType() {
+        return Date.class;
+    }
+
+    @Override
+    public GraphQLScalarType resolve(GraphQLSchemaConfig graphQLSchemaConfig) {
+        if (graphQLSchemaConfig.isDateAsTimestamp())
+            return MappingConstants.graphQLTimestamp;
+        else
+            return new GraphQLDateType("Date", "Date formatted according to defined format string",
+                    graphQLSchemaConfig.getDateFormat());
+
+    }
+}

--- a/src/main/java/com/oembedler/moon/graphql/engine/type/resolver/LocalDateTimeResolver.java
+++ b/src/main/java/com/oembedler/moon/graphql/engine/type/resolver/LocalDateTimeResolver.java
@@ -1,0 +1,30 @@
+package com.oembedler.moon.graphql.engine.type.resolver;
+
+import com.oembedler.moon.graphql.engine.GraphQLSchemaConfig;
+import com.oembedler.moon.graphql.engine.dfs.GraphQLTypeResolver;
+import com.oembedler.moon.graphql.engine.dfs.MappingConstants;
+import com.oembedler.moon.graphql.engine.type.GraphQLLocalDateTimeType;
+import graphql.schema.GraphQLScalarType;
+
+import java.time.LocalDateTime;
+
+/**
+ * @author Sergey Kuptsov
+ * @since 23/03/2017
+ */
+public class LocalDateTimeResolver implements GraphQLTypeResolver {
+    @Override
+    public Class getType() {
+        return LocalDateTime.class;
+    }
+
+    @Override
+    public GraphQLScalarType resolve(GraphQLSchemaConfig graphQLSchemaConfig) {
+        if (graphQLSchemaConfig.isDateAsTimestamp())
+            return MappingConstants.graphQLTimestamp;
+        else {
+            return new GraphQLLocalDateTimeType("LocalDateTime", "LocalDateTime formatted according to defined format string",
+                    graphQLSchemaConfig.getDateFormat());
+        }
+    }
+}

--- a/src/test/java/com/oembedler/moon/graphql/test/todoschema/objecttype/UserObjectType.java
+++ b/src/test/java/com/oembedler/moon/graphql/test/todoschema/objecttype/UserObjectType.java
@@ -20,11 +20,9 @@
 package com.oembedler.moon.graphql.test.todoschema.objecttype;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.oembedler.moon.graphql.engine.stereotype.*;
 import com.oembedler.moon.graphql.test.GenericTodoSchemaParserTest;
 
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
@@ -37,6 +35,7 @@ public class UserObjectType extends BaseObjectType {
 
     private String name;
     private ROLE role;
+    private Date created;
 
     @GraphQLIgnore
     private UserObjectType manager;
@@ -68,6 +67,14 @@ public class UserObjectType extends BaseObjectType {
 
     public void setRole(ROLE role) {
         this.role = role;
+    }
+
+    public Date getCreated() {
+        return created;
+    }
+
+    public void setCreated(Date created) {
+        this.created = created;
     }
 
     @GraphQLField("manager")


### PR DESCRIPTION
1. Added possibility to configure custom type<Class> to GraphQLScalarType resolvers. 
To add resolver you must implement interface com.oembedler.moon.graphql.engine.dfs.GraphQLTypeResolver and add it to configuration with addGraphQLTypeResolver method
2. Do not try to expose private final static contstants - cause they are private - commonly it is unreasonably to expose to client Serializable serialVersionId